### PR TITLE
Ensure JSON responses for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ php artisan serve   # http://127.0.0.1:8000
 1. Importe a coleção `docs/HealthCareAPI.postman_collection.json` no Postman.
 2. Defina a variável `base_url` como `http://127.0.0.1:8000` (ou a URL onde a aplicação está rodando).
 3. Execute as requisições disponíveis na coleção para interagir com a API.
+   Certifique-se de que cada requisição envie o cabeçalho `Accept: application/json`
+   para receber as respostas em formato JSON no Postman.
 
 ## Documentação da API
 

--- a/docs/HealthCareAPI.postman_collection.json
+++ b/docs/HealthCareAPI.postman_collection.json
@@ -8,6 +8,12 @@
       "name": "Listar usuários",
       "request": {
         "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
         "url": "{{base_url}}/api/usuarios"
       }
     },
@@ -15,6 +21,12 @@
       "name": "Buscar usuário por ID",
       "request": {
         "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
         "url": "{{base_url}}/api/usuarios/1"
       }
     },
@@ -25,6 +37,10 @@
         "header": [
           {
             "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Accept",
             "value": "application/json"
           }
         ],
@@ -43,6 +59,10 @@
           {
             "key": "Content-Type",
             "value": "application/json"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json"
           }
         ],
         "body": {
@@ -56,6 +76,12 @@
       "name": "Remover usuário",
       "request": {
         "method": "DELETE",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
         "url": "{{base_url}}/api/usuarios/1"
       }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,9 +10,9 @@ Route::post('/usuarios', [UsuarioController::class, 'store']); // insert user
 // GET
 Route::get('/usuarios', [UsuarioController::class, 'index']); // search all users
 
-Route::get('/usuarios/{id}', [UsuarioController::class, 'show']); // search user for id
-
 Route::get('/usuarios/email/{email}', [UsuarioController::class, 'buscarPorEmail']); // search user for email
+
+Route::get('/usuarios/{id}', [UsuarioController::class, 'show'])->where('id', '[0-9]+'); // search user for id
 
 //PUT
 Route::put('/usuarios/{id}', [UsuarioController::class, 'update']); // update data for user


### PR DESCRIPTION
## Summary
- add Accept header to every request in Postman collection
- note Accept header in README Postman instructions
- constrain user id route to numeric so the email route always matches first

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c0ca4fc832797fa137ef87a19d9